### PR TITLE
split tests and add tolerances

### DIFF
--- a/src/nlp/bound-constrained.jl
+++ b/src/nlp/bound-constrained.jl
@@ -1,15 +1,10 @@
 export bound_constrained_nlp
 
-"""
-    bound_constrained_nlp(solver)
-
-Test the `solver` on bound-constrained problems.
-"""
-function bound_constrained_nlp(solver)
+function bound_constrained_set()
   n = 30
   D = Diagonal([0.1 + 0.9 * (i - 1) / (n - 1) for i = 1:n])
   A = spdiagm(0 => 2 * ones(n), -1 => -ones(n-1), -1 => -ones(n-1))
-  @testset "Problem $(nlp.meta.name)" for nlp in [
+  return [
     ADNLPModel(
       x -> (x[1] - 1)^2 + 4 * (x[2] - 1)^2,
       zeros(2),
@@ -53,13 +48,23 @@ function bound_constrained_nlp(solver)
       name = "Extended Rosenbrock"
     ),
   ]
+end
+
+"""
+    bound_constrained_nlp(solver; problem_set = bound_constrained_set(), atol = 1e-6, rtol = 1e-6)
+
+Test the `solver` on bound-constrained problems.
+If `rtol` is non-zero, the relative error uses the gradient at the initial guess.
+"""
+function bound_constrained_nlp(solver; problem_set = bound_constrained_set(), atol = 1e-6, rtol = 1e-6)
+  @testset "Problem $(nlp.meta.name)" for nlp in problem_set
     stats = with_logger(NullLogger()) do
       solver(nlp)
     end
-    ng0 = norm(grad(nlp, nlp.meta.x0))
-    @test isapprox(stats.solution, ones(nlp.meta.nvar), atol=1e-6 * (ng0 + 1))
-    @test isapprox(stats.objective, 0.0, atol=1e-6 * (ng0 + 1))
-    @test stats.dual_feas < 1e-6 * (ng0 + 1)
+    ng0 = rtol != 0 ? norm(grad(nlp, nlp.meta.x0)) : 0
+    @test isapprox(stats.solution, ones(nlp.meta.nvar), atol = atol + rtol * ng0)
+    @test isapprox(stats.objective, 0.0, atol = atol + rtol * ng0)
+    @test stats.dual_feas < atol + rtol * ng0
     @test stats.status == :first_order
   end
 end

--- a/src/nlp/bound-constrained.jl
+++ b/src/nlp/bound-constrained.jl
@@ -1,6 +1,6 @@
 export bound_constrained_nlp
 
-function bound_constrained_set()
+function bound_constrained_nlp_set()
   n = 30
   D = Diagonal([0.1 + 0.9 * (i - 1) / (n - 1) for i = 1:n])
   A = spdiagm(0 => 2 * ones(n), -1 => -ones(n-1), -1 => -ones(n-1))
@@ -56,7 +56,7 @@ end
 Test the `solver` on bound-constrained problems.
 If `rtol` is non-zero, the relative error uses the gradient at the initial guess.
 """
-function bound_constrained_nlp(solver; problem_set = bound_constrained_set(), atol = 1e-6, rtol = 1e-6)
+function bound_constrained_nlp(solver; problem_set = bound_constrained_nlp_set(), atol = 1e-6, rtol = 1e-6)
   @testset "Problem $(nlp.meta.name)" for nlp in problem_set
     stats = with_logger(NullLogger()) do
       solver(nlp)

--- a/src/nlp/unconstrained.jl
+++ b/src/nlp/unconstrained.jl
@@ -39,15 +39,15 @@ end
 Test the `solver` on unconstrained problems.
 If `rtol` is non-zero, the relative error uses the gradient at the initial guess.
 """
-function unconstrained_nlp(solver; atol=1e-6, rtol=1e-6)
-  @testset "Problem $(nlp.meta.name)" for nlp in unconstrained_set()
+function unconstrained_nlp(solver; problem_set = unconstrained_set(), atol = 1e-6, rtol = 1e-6)
+  @testset "Problem $(nlp.meta.name)" for nlp in problem_set
     stats = with_logger(NullLogger()) do
       solver(nlp)
     end
     ng0 = rtol != 0 ? norm(grad(nlp, nlp.meta.x0)) : 0
-    @test isapprox(stats.solution, ones(nlp.meta.nvar), atol=atol+rtol*ng0)
-    @test isapprox(stats.objective, 0.0, atol=atol+rtol*ng0)
-    @test stats.dual_feas < atol+rtol*ng0
+    @test isapprox(stats.solution, ones(nlp.meta.nvar), atol = atol + rtol * ng0)
+    @test isapprox(stats.objective, 0.0, atol = atol + rtol * ng0)
+    @test stats.dual_feas < atol + rtol * ng0
     @test stats.status == :first_order
   end
 end

--- a/src/nlp/unconstrained.jl
+++ b/src/nlp/unconstrained.jl
@@ -34,7 +34,7 @@ function unconstrained_set()
 end
 
 """
-    unconstrained_nlp(solver; atol=1e-6, rtol=1e-6)
+    unconstrained_nlp(solver; problem_set = unconstrained_set(), atol = 1e-6, rtol = 1e-6)
 
 Test the `solver` on unconstrained problems.
 If `rtol` is non-zero, the relative error uses the gradient at the initial guess.

--- a/src/nlp/unconstrained.jl
+++ b/src/nlp/unconstrained.jl
@@ -1,15 +1,10 @@
 export unconstrained_nlp
 
-"""
-    unconstrained_nlp(solver)
-
-Test the `solver` on unconstrained problems.
-"""
-function unconstrained_nlp(solver)
+function unconstrained_set()
   n = 30
   D = Diagonal([0.1 + 0.9 * (i - 1) / (n - 1) for i = 1:n])
   A = spdiagm(0 => 2 * ones(n), -1 => -ones(n-1), -1 => -ones(n-1))
-  @testset "Problem $(nlp.meta.name)" for nlp in [
+  return [
     ADNLPModel(
       x -> (x[1] - 1)^2 + 4 * (x[2] - 1)^2,
       zeros(2),
@@ -36,13 +31,23 @@ function unconstrained_nlp(solver)
       name = "Extended Rosenbrock"
     ),
   ]
+end
+
+"""
+    unconstrained_nlp(solver; atol=1e-6, rtol=1e-6)
+
+Test the `solver` on unconstrained problems.
+If `rtol` is non-zero, the relative error uses the gradient at the initial guess.
+"""
+function unconstrained_nlp(solver; atol=1e-6, rtol=1e-6)
+  @testset "Problem $(nlp.meta.name)" for nlp in unconstrained_set()
     stats = with_logger(NullLogger()) do
       solver(nlp)
     end
-    ng0 = norm(grad(nlp, nlp.meta.x0))
-    @test isapprox(stats.solution, ones(nlp.meta.nvar), atol=1e-6 * (ng0 + 1))
-    @test isapprox(stats.objective, 0.0, atol=1e-6 * (ng0 + 1))
-    @test stats.dual_feas < 1e-6 * (ng0 + 1)
+    ng0 = rtol != 0 ? norm(grad(nlp, nlp.meta.x0)) : 0
+    @test isapprox(stats.solution, ones(nlp.meta.nvar), atol=atol+rtol*ng0)
+    @test isapprox(stats.objective, 0.0, atol=atol+rtol*ng0)
+    @test stats.dual_feas < atol+rtol*ng0
     @test stats.status == :first_order
   end
 end

--- a/src/nlp/unconstrained.jl
+++ b/src/nlp/unconstrained.jl
@@ -1,6 +1,6 @@
 export unconstrained_nlp
 
-function unconstrained_set()
+function unconstrained_nlp_set()
   n = 30
   D = Diagonal([0.1 + 0.9 * (i - 1) / (n - 1) for i = 1:n])
   A = spdiagm(0 => 2 * ones(n), -1 => -ones(n-1), -1 => -ones(n-1))
@@ -39,7 +39,7 @@ end
 Test the `solver` on unconstrained problems.
 If `rtol` is non-zero, the relative error uses the gradient at the initial guess.
 """
-function unconstrained_nlp(solver; problem_set = unconstrained_set(), atol = 1e-6, rtol = 1e-6)
+function unconstrained_nlp(solver; problem_set = unconstrained_nlp_set(), atol = 1e-6, rtol = 1e-6)
   @testset "Problem $(nlp.meta.name)" for nlp in problem_set
     stats = with_logger(NullLogger()) do
       solver(nlp)

--- a/src/nls/bound-constrained.jl
+++ b/src/nls/bound-constrained.jl
@@ -1,15 +1,10 @@
 export bound_constrained_nls
 
-"""
-    bound_constrained_nls(solver)
-
-Test the `solver` on bound-constrained nonlinear least-squares problems.
-"""
-function bound_constrained_nls(solver)
+function bound_constrained_nls_set()
   n = 30
   D = Diagonal([0.1 + 0.9 * (i - 1) / (n - 1) for i = 1:n])
   A = spdiagm(0 => 2 * ones(n), -1 => -ones(n-1), -1 => -ones(n-1))
-  @testset "Problem $(nls.meta.name)" for nls in [
+  return [
     ADNLSModel(
       x -> [x[1] - 1; 2x[2] - 2],
       zeros(2),
@@ -67,12 +62,22 @@ function bound_constrained_nls(solver)
       name = "Extended Rosenbrock"
     ),
   ]
+end
+
+"""
+    bound_constrained_nls(solver; problem_set = bound_constrained_nls_set(), atol = 1e-6, rtol = 1e-6)
+
+Test the `solver` on bound-constrained nonlinear least-squares problems.
+If `rtol` is non-zero, the relative error uses the gradient at the initial guess.
+"""
+function bound_constrained_nls(solver; problem_set = bound_constrained_nls_set(), atol = 1e-6, rtol = 1e-6)
+  @testset "Problem $(nls.meta.name)" for nls in problem_set
     stats = with_logger(NullLogger()) do
       solver(nls)
     end
-    ng0 = norm(grad(nls, nls.meta.x0))
-    @test isapprox(stats.solution, ones(nls.meta.nvar), atol=1e-6 * (ng0 + 1))
-    @test stats.dual_feas < 1e-6 * (ng0 + 1)
+    ng0 = rtol != 0 ? norm(grad(nls, nls.meta.x0)) : 0
+    @test isapprox(stats.solution, ones(nls.meta.nvar), atol = atol + rtol * ng0)
+    @test stats.dual_feas < atol + rtol * ng0
     @test stats.status == :first_order
   end
 end


### PR DESCRIPTION
This is a suggestion on the nlp-unconstrained tests. If it is pertinent and useful, I can make it on the 3 others.

- add optional `atol` and `rtol` so they can be fine-tuned and if `rtol=0` we don't evaluate the gradient (documented).
- split the test set from the tests, so they can be overloaded to exclude or add some.

Probably more than one way to do the latter, but it looks simple.