### PR TITLE
Add test for equality constrained problems

### DIFF
--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -8,8 +8,10 @@ The following functions are available:
 ```@docs
 unconstrained_nlp
 bound_constrained_nlp
+equality_constrained_nlp
 unconstrained_nls
 bound_constrained_nls
+equality_constrained_nls
 multiprecision_nlp
 multiprecision_nls
 ```

--- a/src/SolverTest.jl
+++ b/src/SolverTest.jl
@@ -7,10 +7,12 @@ using ADNLPModels, NLPModels
 
 include("nlp/unconstrained.jl")
 include("nlp/bound-constrained.jl")
+include("nlp/equality-constrained.jl")
 include("nlp/multiprecision.jl")
 
 include("nls/unconstrained.jl")
 include("nls/bound-constrained.jl")
+include("nls/equality-constrained.jl")
 include("nls/multiprecision.jl")
 
 end # module

--- a/src/nlp/bound-constrained.jl
+++ b/src/nlp/bound-constrained.jl
@@ -51,7 +51,7 @@ function bound_constrained_nlp_set()
 end
 
 """
-    bound_constrained_nlp(solver; problem_set = bound_constrained_set(), atol = 1e-6, rtol = 1e-6)
+    bound_constrained_nlp(solver; problem_set = bound_constrained_nlp_set(), atol = 1e-6, rtol = 1e-6)
 
 Test the `solver` on bound-constrained problems.
 If `rtol` is non-zero, the relative error uses the gradient at the initial guess.

--- a/src/nlp/equality-constrained.jl
+++ b/src/nlp/equality-constrained.jl
@@ -1,0 +1,57 @@
+export equality_constrained_nlp
+
+function equality_constrained_nlp_set()
+  n = 30
+  return [
+    ADNLPModel(x -> 2x[1]^2 + x[1] * x[2] + x[2]^2 - 9x[1] - 9x[2] + 14, 
+               [1.0; 2.0], 
+               x -> [4x[1] + 6x[2] - 10], 
+               zeros(1), zeros(1),
+               name = "Simple quadratic problem"),
+    ADNLPModel(x -> (x[1] - 1)^2, 
+               [-1.2; 1.0], 
+               x -> [10 * (x[2] - x[1]^2)], 
+               zeros(1), zeros(1), 
+               name = "HS6"),
+    ADNLPModel(x -> (x[1] - 1)^2 + 100 * (x[2] - x[1]^2)^2, 
+               [-1.2; 1.0], 
+               x -> [(x[1] - 2)^2 + (x[2] - 2)^2 - 2], 
+               zeros(1), zeros(1),
+               name = "Rosenbrock with (x₁-2)²+(x₂-2)²=2"),
+    ADNLPModel(x -> -x[1] + 1, 
+               [0.5; 1/3], 
+               x -> [16x[1]^2 + 9x[2]^2 - 25; 
+                     4x[1] * 3x[2] - 12], 
+               zeros(2), zeros(2),
+               name = "scaled HS8"),
+    ADNLPModel(x -> dot(x, x) - n, 
+               zeros(n),
+               x -> [sum(x) - n], 
+               zeros(1), zeros(1),
+               name = "‖x‖² s.t. ∑x = n"),
+    ADNLPModel(x -> (x[1] - 1.0)^2 + 100 * (x[2] - x[1]^2)^2, 
+               [-1.2; 1.0],
+               x -> [sum(x) - 2], [0.0], [0.0],
+               name = "Rosenbrock with ∑x = 2"),
+  ]
+end
+
+"""
+    equality_constrained_nlp(solver; problem_set = equality_constrained_nlp_set(), atol = 1e-6, rtol = 1e-6)
+
+Test the `solver` on equality-constrained problems.
+If `rtol` is non-zero, the relative error uses the gradient at the initial guess.
+"""
+function equality_constrained_nlp(solver; problem_set = equality_constrained_nlp_set(), atol = 1e-6, rtol = 1e-6)
+  @testset "Problem $(nlp.meta.name)" for nlp in problem_set
+    stats = with_logger(NullLogger()) do
+      solver(nlp)
+    end
+    ng0 = rtol != 0 ? norm(grad(nlp, nlp.meta.x0)) : 0
+    @test isapprox(stats.solution, ones(nlp.meta.nvar), atol = atol + rtol * ng0)
+    @test isapprox(stats.objective, 0.0, atol = atol + rtol * ng0)
+    @test stats.dual_feas < atol + rtol * ng0
+    @test stats.primal_feas < atol + rtol * ng0
+    @test stats.status == :first_order
+  end
+end

--- a/src/nlp/unconstrained.jl
+++ b/src/nlp/unconstrained.jl
@@ -34,7 +34,7 @@ function unconstrained_nlp_set()
 end
 
 """
-    unconstrained_nlp(solver; problem_set = unconstrained_set(), atol = 1e-6, rtol = 1e-6)
+    unconstrained_nlp(solver; problem_set = unconstrained_nlp_set(), atol = 1e-6, rtol = 1e-6)
 
 Test the `solver` on unconstrained problems.
 If `rtol` is non-zero, the relative error uses the gradient at the initial guess.

--- a/src/nls/equality-constrained.jl
+++ b/src/nls/equality-constrained.jl
@@ -1,0 +1,63 @@
+export equality_constrained_nls
+
+function equality_constrained_nls_set()
+  n = 10
+  return [
+    ADNLSModel(x -> [x[1] - 1], 
+               [-1.2; 1.0], 1,
+               x -> [10 * (x[2] - x[1]^2)], 
+               zeros(1), zeros(1), 
+               name = "HS6"),
+    ADNLSModel(x -> [x[1] - 1 ; 10 * (x[2] - x[1]^2)], 
+               [-1.2; 1.0], 2,
+               x -> [(x[1] - 2)^2 + (x[2] - 2)^2 - 2], 
+               zeros(1), zeros(1),
+               name = "Rosenbrock with (x₁-2)²+(x₂-2)²=2"),
+    ADNLSModel(x -> [x[1] - 1 ; 10 * (x[2] - x[1]^2)],
+               [-1.2; 1.0], 2,
+               x -> [sum(x) - 2], zeros(1), zeros(1),
+               name = "Rosenbrock with ∑x = 2"),
+    ADNLSModel(x -> [x[1] - 1; x[2] - 1],
+               -ones(2), 2,
+               x -> [sum(x) - 2], zeros(1), zeros(1),
+               name = "linear residual and linear constraints"),
+    ADNLSModel(x -> [x[1] - 1; x[2] - 1],
+               -ones(2), 2,
+               x -> [sum(x.^2) - 2; x[2] - x[1]^2], zeros(2), zeros(2),
+               name = "linear residual and quad constraints"),
+    ADNLSModel(x -> [x[1] - x[i] for i = 2:n],
+               [1.0j for j = 1:n] / n, n-1,
+               x -> [sum(x) - n], zeros(1), zeros(1),
+               name = "F_under and linear constraints"),
+    ADNLSModel(x -> [x[1] - x[i] for i = 2:n],
+               [1.0j for j = 1:n] / n, n-1,
+               x -> [sum(x.^2) - n; prod(x) - 1], zeros(2), zeros(2),
+               name = "F_under and quad constraints"),
+    ADNLSModel(x -> [[10 * (x[i+1] - x[i]^2) for i = 1:n-1]; [x[i] - 1 for i = 1:n-1]],
+               0.9 * ones(n), 2(n-1),
+               x -> [sum(x) - n], zeros(1), zeros(1),
+               name = "F_larger and linear constraints"),
+    ADNLSModel(x -> [[10 * (x[i+1] - x[i]^2) for i = 1:n-1]; [x[i] - 1 for i = 1:n-1]],
+               0.9 * ones(n), 2(n-1),
+               x -> [sum(x.^2) - n; prod(x) - 1], zeros(2), zeros(2),
+               name = "F_larger and quad constraints"),
+  ]
+end
+"""
+    equality_constrained_nls(solver; problem_set = equality_constrained_nls_set(), atol = 1e-6, rtol = 1e-6)
+
+Test the `solver` on equality-constrained problems.
+If `rtol` is non-zero, the relative error uses the gradient at the initial guess.
+"""
+function equality_constrained_nls(solver; problem_set = equality_constrained_nls_set(), atol = 1e-6, rtol = 1e-6)
+  @testset "Problem $(nls.meta.name)" for nls in problem_set
+    stats = with_logger(NullLogger()) do
+      solver(nls)
+    end
+    ng0 = rtol != 0 ? norm(grad(nls, nls.meta.x0)) : 0
+    @test isapprox(stats.solution, ones(nls.meta.nvar), atol = atol + rtol * ng0)
+    @test stats.dual_feas < atol + rtol * ng0
+    @test stats.primal_feas < atol + rtol * ng0
+    @test stats.status == :first_order
+  end
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -9,8 +9,10 @@ include("dummy-solver.jl")
   @testset "$foo" for foo in [
     unconstrained_nlp,
     bound_constrained_nlp,
+    equality_constrained_nlp,
     unconstrained_nls,
     bound_constrained_nls,
+    equality_constrained_nls,
   ]
     foo(dummy)
   end


### PR DESCRIPTION
- Add test for equality constrained `nlp`, merged test problems from `Percival.jl` and some from `DCISolver.jl`.
- Add test for equality constrained `nls`, reuse quadratic test from `nlp` and add `CaNNOLeS.jl` problems.
- Add a try/catch in dummy solver as the `\` failed in one test.