### PR TITLE
Allow to pass kwargs to solvers

### DIFF
--- a/src/nlp/bound-constrained.jl
+++ b/src/nlp/bound-constrained.jl
@@ -76,7 +76,11 @@ function bound_constrained_nlp(
 )
   @testset "Problem $(nlp.meta.name)" for nlp in problem_set
     stats = with_logger(NullLogger()) do
-      solver(nlp; kwargs...)
+      solver(nlp;
+        atol = atol,
+        rtol = rtol, 
+        kwargs...
+      )
     end
     ng0 = rtol != 0 ? norm(grad(nlp, nlp.meta.x0)) : 0
     ϵ = atol + rtol * ng0

--- a/src/nlp/bound-constrained.jl
+++ b/src/nlp/bound-constrained.jl
@@ -65,7 +65,7 @@ end
 
 Test the `solver` on bound-constrained problems.
 If `rtol` is non-zero, the relative error uses the gradient at the initial guess.
-Additionnal keyword arguments are passed to the solver.
+Additional keyword arguments are passed to the solver.
 """
 function bound_constrained_nlp(
   solver;

--- a/src/nlp/bound-constrained.jl
+++ b/src/nlp/bound-constrained.jl
@@ -61,20 +61,22 @@ function bound_constrained_nlp_set(; kwargs...)
 end
 
 """
-    bound_constrained_nlp(solver; problem_set = bound_constrained_nlp_set(), atol = 1e-6, rtol = 1e-6)
+    bound_constrained_nlp(solver; problem_set = bound_constrained_nlp_set(), atol = 1e-6, rtol = 1e-6, kwargs...)
 
 Test the `solver` on bound-constrained problems.
 If `rtol` is non-zero, the relative error uses the gradient at the initial guess.
+Additionnal keyword arguments are passed to the solver.
 """
 function bound_constrained_nlp(
   solver;
   problem_set = bound_constrained_nlp_set(),
   atol = 1e-6,
   rtol = 1e-6,
+  kwargs...
 )
   @testset "Problem $(nlp.meta.name)" for nlp in problem_set
     stats = with_logger(NullLogger()) do
-      solver(nlp)
+      solver(nlp; kwargs...)
     end
     ng0 = rtol != 0 ? norm(grad(nlp, nlp.meta.x0)) : 0
     ϵ = atol + rtol * ng0

--- a/src/nlp/equality-constrained.jl
+++ b/src/nlp/equality-constrained.jl
@@ -55,20 +55,22 @@ function equality_constrained_nlp_set(; kwargs...)
 end
 
 """
-    equality_constrained_nlp(solver; problem_set = equality_constrained_nlp_set(), atol = 1e-6, rtol = 1e-6)
+    equality_constrained_nlp(solver; problem_set = equality_constrained_nlp_set(), atol = 1e-6, rtol = 1e-6, kwargs...)
 
 Test the `solver` on equality-constrained problems.
 If `rtol` is non-zero, the relative error uses the gradient at the initial guess.
+Additionnal keyword arguments are passed to the solver.
 """
 function equality_constrained_nlp(
   solver;
   problem_set = equality_constrained_nlp_set(),
   atol = 1e-6,
   rtol = 1e-6,
+  kwargs...,
 )
   @testset "Problem $(nlp.meta.name)" for nlp in problem_set
     stats = with_logger(NullLogger()) do
-      solver(nlp)
+      solver(nlp; kwargs...)
     end
     ng0 = rtol != 0 ? norm(grad(nlp, nlp.meta.x0)) : 0
     ϵ = atol + rtol * ng0

--- a/src/nlp/equality-constrained.jl
+++ b/src/nlp/equality-constrained.jl
@@ -70,7 +70,11 @@ function equality_constrained_nlp(
 )
   @testset "Problem $(nlp.meta.name)" for nlp in problem_set
     stats = with_logger(NullLogger()) do
-      solver(nlp; kwargs...)
+      solver(nlp;
+        atol = atol,
+        rtol = rtol, 
+        kwargs...
+      )
     end
     ng0 = rtol != 0 ? norm(grad(nlp, nlp.meta.x0)) : 0
     ϵ = atol + rtol * ng0

--- a/src/nlp/equality-constrained.jl
+++ b/src/nlp/equality-constrained.jl
@@ -59,7 +59,7 @@ end
 
 Test the `solver` on equality-constrained problems.
 If `rtol` is non-zero, the relative error uses the gradient at the initial guess.
-Additionnal keyword arguments are passed to the solver.
+Additional keyword arguments are passed to the solver.
 """
 function equality_constrained_nlp(
   solver;

--- a/src/nlp/unconstrained.jl
+++ b/src/nlp/unconstrained.jl
@@ -33,15 +33,16 @@ function unconstrained_nlp_set(; kwargs...)
 end
 
 """
-    unconstrained_nlp(solver; problem_set = unconstrained_nlp_set(), atol = 1e-6, rtol = 1e-6)
+    unconstrained_nlp(solver; problem_set = unconstrained_nlp_set(), atol = 1e-6, rtol = 1e-6, kwargs...)
 
 Test the `solver` on unconstrained problems.
 If `rtol` is non-zero, the relative error uses the gradient at the initial guess.
+Additionnal keyword arguments are passed to the solver.
 """
-function unconstrained_nlp(solver; problem_set = unconstrained_nlp_set(), atol = 1e-6, rtol = 1e-6)
+function unconstrained_nlp(solver; problem_set = unconstrained_nlp_set(), atol = 1e-6, rtol = 1e-6, kwargs...)
   @testset "Problem $(nlp.meta.name)" for nlp in problem_set
     stats = with_logger(NullLogger()) do
-      solver(nlp)
+      solver(nlp; kwargs...)
     end
     ng0 = rtol != 0 ? norm(grad(nlp, nlp.meta.x0)) : 0
     ϵ = atol + rtol * ng0

--- a/src/nlp/unconstrained.jl
+++ b/src/nlp/unconstrained.jl
@@ -42,7 +42,11 @@ Additionnal keyword arguments are passed to the solver.
 function unconstrained_nlp(solver; problem_set = unconstrained_nlp_set(), atol = 1e-6, rtol = 1e-6, kwargs...)
   @testset "Problem $(nlp.meta.name)" for nlp in problem_set
     stats = with_logger(NullLogger()) do
-      solver(nlp; kwargs...)
+      solver(nlp;
+        atol = atol,
+        rtol = rtol, 
+        kwargs...
+      )
     end
     ng0 = rtol != 0 ? norm(grad(nlp, nlp.meta.x0)) : 0
     ϵ = atol + rtol * ng0

--- a/src/nlp/unconstrained.jl
+++ b/src/nlp/unconstrained.jl
@@ -37,7 +37,7 @@ end
 
 Test the `solver` on unconstrained problems.
 If `rtol` is non-zero, the relative error uses the gradient at the initial guess.
-Additionnal keyword arguments are passed to the solver.
+Additional keyword arguments are passed to the solver.
 """
 function unconstrained_nlp(solver; problem_set = unconstrained_nlp_set(), atol = 1e-6, rtol = 1e-6, kwargs...)
   @testset "Problem $(nlp.meta.name)" for nlp in problem_set

--- a/src/nls/bound-constrained.jl
+++ b/src/nls/bound-constrained.jl
@@ -68,20 +68,22 @@ function bound_constrained_nls_set(; kwargs...)
 end
 
 """
-    bound_constrained_nls(solver; problem_set = bound_constrained_nls_set(), atol = 1e-6, rtol = 1e-6)
+    bound_constrained_nls(solver; problem_set = bound_constrained_nls_set(), atol = 1e-6, rtol = 1e-6, kwargs...)
 
 Test the `solver` on bound-constrained nonlinear least-squares problems.
 If `rtol` is non-zero, the relative error uses the gradient at the initial guess.
+Additionnal keyword arguments are passed to the solver.
 """
 function bound_constrained_nls(
   solver;
   problem_set = bound_constrained_nls_set(),
   atol = 1e-6,
   rtol = 1e-6,
+  kwargs...
 )
   @testset "Problem $(nls.meta.name)" for nls in problem_set
     stats = with_logger(NullLogger()) do
-      solver(nls)
+      solver(nls; kwargs...)
     end
     ng0 = rtol != 0 ? norm(grad(nls, nls.meta.x0)) : 0
     ϵ = atol + rtol * ng0

--- a/src/nls/bound-constrained.jl
+++ b/src/nls/bound-constrained.jl
@@ -72,7 +72,7 @@ end
 
 Test the `solver` on bound-constrained nonlinear least-squares problems.
 If `rtol` is non-zero, the relative error uses the gradient at the initial guess.
-Additionnal keyword arguments are passed to the solver.
+Additional keyword arguments are passed to the solver.
 """
 function bound_constrained_nls(
   solver;

--- a/src/nls/bound-constrained.jl
+++ b/src/nls/bound-constrained.jl
@@ -83,7 +83,11 @@ function bound_constrained_nls(
 )
   @testset "Problem $(nls.meta.name)" for nls in problem_set
     stats = with_logger(NullLogger()) do
-      solver(nls; kwargs...)
+      solver(nls;
+        atol = atol,
+        rtol = rtol, 
+        kwargs...
+      )
     end
     ng0 = rtol != 0 ? norm(grad(nls, nls.meta.x0)) : 0
     ϵ = atol + rtol * ng0

--- a/src/nls/equality-constrained.jl
+++ b/src/nls/equality-constrained.jl
@@ -96,20 +96,22 @@ function equality_constrained_nls_set(; kwargs...)
   ]
 end
 """
-    equality_constrained_nls(solver; problem_set = equality_constrained_nls_set(), atol = 1e-6, rtol = 1e-6)
+    equality_constrained_nls(solver; problem_set = equality_constrained_nls_set(), atol = 1e-6, rtol = 1e-6, kwargs...)
 
 Test the `solver` on equality-constrained problems.
 If `rtol` is non-zero, the relative error uses the gradient at the initial guess.
+Additionnal keyword arguments are passed to the solver.
 """
 function equality_constrained_nls(
   solver;
   problem_set = equality_constrained_nls_set(),
   atol = 1e-6,
   rtol = 1e-6,
+  kwargs...,
 )
   @testset "Problem $(nls.meta.name)" for nls in problem_set
     stats = with_logger(NullLogger()) do
-      solver(nls)
+      solver(nls; kwargs...)
     end
     ng0 = rtol != 0 ? norm(grad(nls, nls.meta.x0)) : 0
     ϵ = atol + rtol * ng0

--- a/src/nls/equality-constrained.jl
+++ b/src/nls/equality-constrained.jl
@@ -111,7 +111,11 @@ function equality_constrained_nls(
 )
   @testset "Problem $(nls.meta.name)" for nls in problem_set
     stats = with_logger(NullLogger()) do
-      solver(nls; kwargs...)
+      solver(nls;
+        atol = atol,
+        rtol = rtol, 
+        kwargs...
+      )
     end
     ng0 = rtol != 0 ? norm(grad(nls, nls.meta.x0)) : 0
     ϵ = atol + rtol * ng0

--- a/src/nls/equality-constrained.jl
+++ b/src/nls/equality-constrained.jl
@@ -100,7 +100,7 @@ end
 
 Test the `solver` on equality-constrained problems.
 If `rtol` is non-zero, the relative error uses the gradient at the initial guess.
-Additionnal keyword arguments are passed to the solver.
+Additional keyword arguments are passed to the solver.
 """
 function equality_constrained_nls(
   solver;

--- a/src/nls/unconstrained.jl
+++ b/src/nls/unconstrained.jl
@@ -47,7 +47,7 @@ end
 
 Test the `solver` on unconstrained nonlinear least-squares problems.
 If `rtol` is non-zero, the relative error uses the gradient at the initial guess.
-Additionnal keyword arguments are passed to the solver.
+Additional keyword arguments are passed to the solver.
 """
 function unconstrained_nls(solver; problem_set = unconstrained_nls_set(), atol = 1e-6, rtol = 1e-6, kwargs...)
   @testset "Problem $(nls.meta.name)" for nls in problem_set

--- a/src/nls/unconstrained.jl
+++ b/src/nls/unconstrained.jl
@@ -52,7 +52,11 @@ Additionnal keyword arguments are passed to the solver.
 function unconstrained_nls(solver; problem_set = unconstrained_nls_set(), atol = 1e-6, rtol = 1e-6, kwargs...)
   @testset "Problem $(nls.meta.name)" for nls in problem_set
     stats = with_logger(NullLogger()) do
-      solver(nls; kwargs...)
+      solver(nls;
+        atol = atol,
+        rtol = rtol, 
+        kwargs...
+      )
     end
     ng0 = rtol != 0 ? norm(grad(nls, nls.meta.x0)) : 0
     ϵ = atol + rtol * ng0

--- a/src/nls/unconstrained.jl
+++ b/src/nls/unconstrained.jl
@@ -43,15 +43,16 @@ function unconstrained_nls_set(; kwargs...)
 end
 
 """
-    unconstrained_nls(solver; problem_set = unconstrained_nls_set(), atol = 1e-6, rtol = 1e-6)
+    unconstrained_nls(solver; problem_set = unconstrained_nls_set(), atol = 1e-6, rtol = 1e-6, kwargs...)
 
 Test the `solver` on unconstrained nonlinear least-squares problems.
 If `rtol` is non-zero, the relative error uses the gradient at the initial guess.
+Additionnal keyword arguments are passed to the solver.
 """
-function unconstrained_nls(solver; problem_set = unconstrained_nls_set(), atol = 1e-6, rtol = 1e-6)
+function unconstrained_nls(solver; problem_set = unconstrained_nls_set(), atol = 1e-6, rtol = 1e-6, kwargs...)
   @testset "Problem $(nls.meta.name)" for nls in problem_set
     stats = with_logger(NullLogger()) do
-      solver(nls)
+      solver(nls; kwargs...)
     end
     ng0 = rtol != 0 ? norm(grad(nls, nls.meta.x0)) : 0
     ϵ = atol + rtol * ng0

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -13,6 +13,7 @@ using NLPModels, SolverCore, SolverTest
     equality_constrained_nls,
   ]
     foo(SolverTest.dummy)
+    foo(SolverTest.dummy, atol = 0.01)
   end
 
   @testset "Multiprecision tests NLP" begin


### PR DESCRIPTION
Hi, I am trying to allow for looser tolerances in the test sets of `RegularizedOptimization.jl`, this should allow me to do this.

Can one of you review and merge if it looks good to you ? @tmigot @dpo @amontoison.
I'd need a release afterwards.

Thank you !